### PR TITLE
fix: correct upgrade parameter and overprovision

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,8 @@ resource "azurerm_linux_virtual_machine_scale_set" "self_hosted_runners" {
   admin_password                  = length(var.ssh_public_keys) == 0 ? local.password : null
   disable_password_authentication = length(var.ssh_public_keys) > 0
   tags                            = var.tags
-  upgrade_mode                    = "Automatic"
+  upgrade_mode                    = "Manual"
+  overprovision                   = false
 
   dynamic "admin_ssh_key" {
     for_each = var.ssh_public_keys


### PR DESCRIPTION
Signed-off-by: Ketil Gjerde <ketil.gjerde@amesto.no>

As recommended by https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/scale-set-agents?view=azure-devops#create-the-scale-set
these parameters have required values:

--disable-overprovision - required
--upgrade-policy-mode manual - required


